### PR TITLE
fix: warn and skip non-existent task IDs instead of failing

### DIFF
--- a/__tests__/change_status.test.ts
+++ b/__tests__/change_status.test.ts
@@ -62,8 +62,45 @@ describe('Test non-existent task', () => {
         await run()
 
         expect(infoMock).toHaveBeenCalledWith('Changed the status of ABC-123 to in review successfully.')
-        expect(warningMock).toHaveBeenCalledWith('Task NON-123 not found in ClickUp, skipping.')
+        expect(warningMock).toHaveBeenCalledWith('Task NON-123 not found in ClickUp (404), skipping.')
         expect(failedMock).not.toHaveBeenCalled()
+    })
+})
+
+describe('Test GET server error', () => {
+    it('fails when GET returns a non-404 error', async () => {
+        const failedMock = jest.spyOn(core, 'setFailed')
+        const errorMock = jest.spyOn(core, 'error')
+
+        nock('https://api.clickup.com')
+            .get('/api/v2/task/ABC-123/?custom_task_ids=true&team_id=123')
+            .reply(500, { err: 'Internal Server Error' })
+
+        process.env['INPUT_CLICKUP_CUSTOM_TASK_IDS'] = 'ABC-123'
+        await run()
+
+        expect(errorMock).toHaveBeenCalledWith(expect.stringContaining('ABC-123 GET error:'))
+        expect(failedMock).toHaveBeenCalledWith('Action failed: One of the API requests has failed. Please check the logs for more details.')
+    })
+})
+
+describe('Test PUT failure after successful GET', () => {
+    it('fails when PUT returns an error for a valid task', async () => {
+        const failedMock = jest.spyOn(core, 'setFailed')
+        const errorMock = jest.spyOn(core, 'error')
+
+        nock('https://api.clickup.com')
+            .get('/api/v2/task/ABC-123/?custom_task_ids=true&team_id=123')
+            .reply(200, apiReply)
+        nock('https://api.clickup.com')
+            .put('/api/v2/task/ABC-123/?custom_task_ids=true&team_id=123')
+            .reply(403, { err: 'Forbidden' })
+
+        process.env['INPUT_CLICKUP_CUSTOM_TASK_IDS'] = 'ABC-123'
+        await run()
+
+        expect(errorMock).toHaveBeenCalledWith(expect.stringContaining('ABC-123 error:'))
+        expect(failedMock).toHaveBeenCalledWith('Action failed: One of the API requests has failed. Please check the logs for more details.')
     })
 })
 
@@ -76,8 +113,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-    delete process.env['GITHUB_REPOSITORY']
-    delete process.env['INPUT_TOKEN']
+    delete process.env['INPUT_CLICKUP_TOKEN']
+    delete process.env['INPUT_CLICKUP_CUSTOM_TASK_IDS']
+    delete process.env['INPUT_CLICKUP_TEAM_ID']
+    delete process.env['INPUT_CLICKUP_STATUS']
     nock.cleanAll()
     jest.restoreAllMocks()
 })

--- a/__tests__/change_status.test.ts
+++ b/__tests__/change_status.test.ts
@@ -1,51 +1,76 @@
-// Mocking the github context https://github.com/actions/toolkit/blob/master/docs/github-package.md#mocking-the-github-context
-
 import * as core from '@actions/core'
 import run from '../change_status'
 import nock from "nock";
 
+const apiReply = {
+    "id": "9hx",
+    "custom_id": null,
+    "name": "Updated Task Name",
+    "text_content": "Updated Task Content",
+    "description": "Updated Task Content",
+    "status": {
+        "status": "in review",
+        "color": "#d3d3d3",
+        "orderindex": 1,
+        "type": "custom"
+    }
+}
+
 describe('Test happy path', () => {
     it('does a call to the Clickup API', async () => {
-        // Mocks
         const failedMock = jest.spyOn(core, 'setFailed')
         const infoMock = jest.spyOn(core, 'info')
-        const apiReply = {
-            "id": "9hx",
-            "custom_id": null,
-            "name": "Updated Task Name",
-            "text_content": "Updated Task Content",
-            "description": "Updated Task Content",
-            "status": {
-                "status": "in review",
-                "color": "#d3d3d3",
-                "orderindex": 1,
-                "type": "custom"
-            }
-        }
+
         nock('https://api.clickup.com')
-            .persist()
+            .get('/api/v2/task/ABC-123/?custom_task_ids=true&team_id=123')
+            .reply(200, apiReply)
+        nock('https://api.clickup.com')
             .put('/api/v2/task/ABC-123/?custom_task_ids=true&team_id=123')
             .reply(200, apiReply)
         nock('https://api.clickup.com')
-            .persist()
+            .get('/api/v2/task/DEF-123/?custom_task_ids=true&team_id=123')
+            .reply(200, apiReply)
+        nock('https://api.clickup.com')
             .put('/api/v2/task/DEF-123/?custom_task_ids=true&team_id=123')
             .reply(200, apiReply)
 
-
-
         await run()
 
-        // Assertions
         expect(infoMock).toHaveBeenCalledWith('Changed the status of ABC-123 to in review successfully.')
         expect(infoMock).toHaveBeenCalledWith('Changed the status of DEF-123 to in review successfully.')
-        expect(failedMock).toHaveBeenCalledWith('Action failed: One of the API requests has failed. Please check the logs for more details.')
+        expect(failedMock).not.toHaveBeenCalled()
+    })
+})
+
+describe('Test non-existent task', () => {
+    it('warns and skips tasks that do not exist in ClickUp', async () => {
+        const failedMock = jest.spyOn(core, 'setFailed')
+        const warningMock = jest.spyOn(core, 'warning')
+        const infoMock = jest.spyOn(core, 'info')
+
+        nock('https://api.clickup.com')
+            .get('/api/v2/task/ABC-123/?custom_task_ids=true&team_id=123')
+            .reply(200, apiReply)
+        nock('https://api.clickup.com')
+            .put('/api/v2/task/ABC-123/?custom_task_ids=true&team_id=123')
+            .reply(200, apiReply)
+        nock('https://api.clickup.com')
+            .get('/api/v2/task/NON-123/?custom_task_ids=true&team_id=123')
+            .reply(404, { err: 'Task not found' })
+
+        process.env['INPUT_CLICKUP_CUSTOM_TASK_IDS'] = 'ABC-123\nNON-123'
+        await run()
+
+        expect(infoMock).toHaveBeenCalledWith('Changed the status of ABC-123 to in review successfully.')
+        expect(warningMock).toHaveBeenCalledWith('Task NON-123 not found in ClickUp, skipping.')
+        expect(failedMock).not.toHaveBeenCalled()
     })
 })
 
 beforeEach(() => {
     jest.resetModules()
     process.env['INPUT_CLICKUP_TOKEN'] = 'xyz'
-    process.env['INPUT_CLICKUP_CUSTOM_TASK_IDS'] = 'ABC-123\nDEF-123\nNON-123'
+    process.env['INPUT_CLICKUP_CUSTOM_TASK_IDS'] = 'ABC-123\nDEF-123'
     process.env['INPUT_CLICKUP_TEAM_ID'] = '123'
     process.env['INPUT_CLICKUP_STATUS'] = 'in review'
 })
@@ -53,4 +78,6 @@ beforeEach(() => {
 afterEach(() => {
     delete process.env['GITHUB_REPOSITORY']
     delete process.env['INPUT_TOKEN']
+    nock.cleanAll()
+    jest.restoreAllMocks()
 })

--- a/change_status.ts
+++ b/change_status.ts
@@ -21,8 +21,13 @@ const run = async (): Promise<void> => {
 
             try {
                 await axios.get(endpoint, { headers })
-            } catch {
-                core.warning(`Task ${task_id} not found in ClickUp, skipping.`)
+            } catch (error) {
+                if (axios.isAxiosError(error) && error.response?.status === 404) {
+                    core.warning(`Task ${task_id} not found in ClickUp (404), skipping.`)
+                    continue
+                }
+                failed = true
+                core.error(`${task_id} GET error: ${error instanceof Error ? error.message : error}`)
                 continue
             }
 
@@ -34,7 +39,7 @@ const run = async (): Promise<void> => {
             ).catch(
                 function (error) {
                     failed = true
-                    core.info(`${task_id} error: ${error.message}`)
+                    core.error(`${task_id} error: ${error.message}`)
                 }
             )
         }

--- a/change_status.ts
+++ b/change_status.ts
@@ -13,15 +13,22 @@ const run = async (): Promise<void> => {
         }
 
         for (const task_id of task_ids) {
-            let endpoint = `https://api.clickup.com/api/v2/task/${task_id}/?custom_task_ids=true&team_id=${team_id}`
-            await axios.put(endpoint, body, {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': token
-                }
-            }).then(
-                    (result) => {
-                    let new_status = result.data.status.status
+            const endpoint = `https://api.clickup.com/api/v2/task/${task_id}/?custom_task_ids=true&team_id=${team_id}`
+            const headers = {
+                'Content-Type': 'application/json',
+                'Authorization': token
+            }
+
+            try {
+                await axios.get(endpoint, { headers })
+            } catch {
+                core.warning(`Task ${task_id} not found in ClickUp, skipping.`)
+                continue
+            }
+
+            await axios.put(endpoint, body, { headers }).then(
+                (result) => {
+                    const new_status = result.data.status.status
                     core.info(`Changed the status of ${task_id} to ${new_status} successfully.`)
                 }
             ).catch(

--- a/dist/index.js
+++ b/dist/index.js
@@ -6189,8 +6189,13 @@ const run = async () => {
             try {
                 await axios_1.default.get(endpoint, { headers });
             }
-            catch {
-                core.warning(`Task ${task_id} not found in ClickUp, skipping.`);
+            catch (error) {
+                if (axios_1.default.isAxiosError(error) && error.response?.status === 404) {
+                    core.warning(`Task ${task_id} not found in ClickUp (404), skipping.`);
+                    continue;
+                }
+                failed = true;
+                core.error(`${task_id} GET error: ${error instanceof Error ? error.message : error}`);
                 continue;
             }
             await axios_1.default.put(endpoint, body, { headers }).then((result) => {
@@ -6198,7 +6203,7 @@ const run = async () => {
                 core.info(`Changed the status of ${task_id} to ${new_status} successfully.`);
             }).catch(function (error) {
                 failed = true;
-                core.info(`${task_id} error: ${error.message}`);
+                core.error(`${task_id} error: ${error.message}`);
             });
         }
         if (failed) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6181,14 +6181,20 @@ const run = async () => {
             "status": target_status
         };
         for (const task_id of task_ids) {
-            let endpoint = `https://api.clickup.com/api/v2/task/${task_id}/?custom_task_ids=true&team_id=${team_id}`;
-            await axios_1.default.put(endpoint, body, {
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': token
-                }
-            }).then((result) => {
-                let new_status = result.data.status.status;
+            const endpoint = `https://api.clickup.com/api/v2/task/${task_id}/?custom_task_ids=true&team_id=${team_id}`;
+            const headers = {
+                'Content-Type': 'application/json',
+                'Authorization': token
+            };
+            try {
+                await axios_1.default.get(endpoint, { headers });
+            }
+            catch {
+                core.warning(`Task ${task_id} not found in ClickUp, skipping.`);
+                continue;
+            }
+            await axios_1.default.put(endpoint, body, { headers }).then((result) => {
+                const new_status = result.data.status.status;
                 core.info(`Changed the status of ${task_id} to ${new_status} successfully.`);
             }).catch(function (error) {
                 failed = true;


### PR DESCRIPTION
## Summary
- Validates each task ID with a GET request before attempting the PUT to change status
- If a task doesn't exist in ClickUp (404), logs a warning and skips it instead of failing the entire action
- Prevents false-positive regex matches (e.g. `CVE-2026` from `CVE-2026-45075`) from breaking release workflows

## Test plan
- [x] `npm test` passes — covers happy path and non-existent task skip
- [ ] Re-run failed variapack workflow after deploying both this fix and the regex fix in magento-workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)